### PR TITLE
Replacing <del> with proper strikethrough

### DIFF
--- a/docs/ciscoios.md
+++ b/docs/ciscoios.md
@@ -1,6 +1,6 @@
 # Cisco IOS
 
-IOS is the OS running on the Cisco switches. It can be terrifying, because one wrong move and you've kicked `<del>`redbrick`</del>` DCU off the internet. It's also very different to anything running on any of the servers.
+IOS is the OS running on the Cisco switches. It can be terrifying, because one wrong move and you've kicked ~~redbrick~~ DCU off the internet. It's also very different to anything running on any of the servers.
 
 ## A Quick Walkthrough
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,9 @@ New admins, read:
 
 *  [IRC](irc)
 
-*  `<del>`[jabber](jabber)`</del>`
+*  ~~[jabber](jabber)~~
 
-*  `<del>`[peepd](peepd)`</del>`
+*  ~~[peepd](peepd)~~
 
 *  [Webchat (qwebirc)](webchat)
 #### Ldap
@@ -61,7 +61,7 @@ New admins, read:
 
 *  [Current NFS setup](nfs)
 
-*  `<del>`[Fast storage space for users](faststorage)`</del>`
+*  ~~[Fast storage space for users](faststorage)~~
 #### Mail
 
 *  [Exim email setup](exim)
@@ -89,7 +89,7 @@ New admins, read:
 
 *  [tunnel.redbrick.dcu.ie](tunnel.redbrick.dcu.ie)
 
-*  `<del>`[VPN to Severus](severus_vpn)`</del>`
+*  ~~[VPN to Severus](severus_vpn)~~
 
 *  [Switch Setup](Switch)
 
@@ -146,7 +146,7 @@ New admins, read:
 
 *  [Pygmalion](pyg)
 
-*  `<del>`[Carbon](carbon)`</del>`
+*  ~~[Carbon](carbon)~~
 ### Web
 
 #### Murphy
@@ -224,7 +224,7 @@ Stuff from the Ubuntu 6.06 days
 
 *  [basementcat ](basementcat)
 
-*  `<del>` [ceilingcat](ceilingcat)`</del>`
+*  ~~ [ceilingcat](ceilingcat)~~
 ## Hardware
 
 ### Switches
@@ -233,7 +233,7 @@ Stuff from the Ubuntu 6.06 days
 
 *  [hadron](hadron)
 
-*  `<del>`[enzyme](enzyme)`</del>`
+*  ~~[enzyme](enzyme)~~
 
 *  [JunOS](junos) 
 
@@ -249,7 +249,7 @@ Stuff from the Ubuntu 6.06 days
 
 *  [Pike (IP-KVM)](pike)
 
-* `<del>` [Munger (Printer)](munger)`</del>`
+* ~~ [Munger (Printer)](munger)~~
 
 ## Software
 
@@ -332,9 +332,9 @@ This stuff doesn't reflect the current setup, but may be useful sometime.
 
 #### Old Hardware
 
-*  `<del>`[Minerva general setup info](minerva)`</del>`
+*  ~~[Minerva general setup info](minerva)~~
 
-*  `<del>`[Minerva storage setup and performance issues/solutions](minervastorage)`</del>`
+*  ~~[Minerva storage setup and performance issues/solutions](minervastorage)~~
 
 
 # Useful Links

--- a/docs/legacy/procedures/10.04-services-checklist.md
+++ b/docs/legacy/procedures/10.04-services-checklist.md
@@ -1,45 +1,45 @@
 Stuff that needs to be beaten profusely into working on 10.04 again!:
 
 
-*  `<del>`LDAP  - haus`</del>`
+*  ~~LDAP  - haus~~
 
 
-*  `<del>` INN `</del>`
+*  ~~ INN ~~
  
 
-*  `<del>`IRC - bunbun`</del>`
+*  ~~IRC - bunbun~~
     
 
-*  `<del>`Mail - haus`</del>`
+*  ~~Mail - haus~~
 
 
-*  `<del>`Mailman - haus`</del>`
+*  ~~Mailman - haus~~
 
 
-*  `<del>` DNS `</del>`
+*  ~~ DNS ~~
 
 
-*  `<del>`Anyterm - vadim `</del>`
+*  ~~Anyterm - vadim ~~
 
 
-*  `<del>`Ajaxterm - vadim `</del>`
+*  ~~Ajaxterm - vadim ~~
 
 
-*  `<del>`bitlbee - bunbun`</del>`
+*  ~~bitlbee - bunbun~~
 
 
-*  `<del>`webmail - vadim`</del>`
+*  ~~webmail - vadim~~
 
 
-*  `<del>`imap (dovecot)`</del>`
+*  ~~imap (dovecot)~~
  
 
-*  `<del>`mysql - fun`</del>`
+*  ~~mysql - fun~~
 
 
-*  `<del>`webchat - vadim`</del>`
+*  ~~webchat - vadim~~
 
 
-*  `<del>`dhcp server - fun`</del>`
+*  ~~dhcp server - fun~~
 
 

--- a/docs/legacy/procedures/10.04move.md
+++ b/docs/legacy/procedures/10.04move.md
@@ -1,7 +1,7 @@
 Stuff that needs to get done:
 
 
-*  `<del>`Get a red dell and set it up for secondary LDAP and DNS`</del>`
+*  ~~Get a red dell and set it up for secondary LDAP and DNS~~
 
 
 

--- a/docs/nagios_to_do.md
+++ b/docs/nagios_to_do.md
@@ -15,6 +15,6 @@
 
 *  pf on b4/severus
 
-*  `<del>` daniel `</del>` - done
+*  ~~ daniel ~~ - done
 
 *  hadron & Enzyme

--- a/docs/nfs.md
+++ b/docs/nfs.md
@@ -8,7 +8,7 @@ Carbon, morpheus and murphy mount /storage over NFS. On each machine, /home and 
 
 [Thunder](thunder) is the local backup server. It can mount all nfs points readonly, read the [dirvish](dirvish) docs for more about this. /backup is local on thunder, and should be mounted readonly on minerva so people can get files from backups. It is not mounted automatically on any other machine.
 
-`<del>`Deathray, murphy, morpheus and minerva all mount /fast-storage from carbon. /srv is should be a symlink to /fast-storage/srv`</del>` RIP /fast-storage
+~~Deathray, murphy, morpheus and minerva all mount /fast-storage from carbon. /srv is should be a symlink to /fast-storage/srv~~ RIP /fast-storage
 
 To be able to setquota on /storage remotely add RPCRQUOTADOPTS='--setquota' (that's 2 dashes, fuck you, dokuwiki) to /etc/default/quota (on DebUntu) on the the machine hosting NFS.
 

--- a/docs/stuff_that_needs_doing_before_we_can_buy_new_servers.md
+++ b/docs/stuff_that_needs_doing_before_we_can_buy_new_servers.md
@@ -6,9 +6,9 @@ This list is in order of priority.
 
 - munin needs to be configured properly on all of our current machines. http://munin.redbrick.dcu.ie - haus 
 
-- `<del>`nagios needs to be configured properly on all of our current machines. http://nagios.redbrick.dcu.ie`</del>` - haus 
+- ~~nagios needs to be configured properly on all of our current machines. http://nagios.redbrick.dcu.ie~~ - haus 
 
-- `<del>`remote logging also isn't set up on a number of machines (most importantly our primary services machine)`</del>` - haus
+- ~~remote logging also isn't set up on a number of machines (most importantly our primary services machine)~~ - haus
 
 - Minerva needs to be installed with windows - isaac702, because he's a windows fanboi
 

--- a/docs/thunder.md
+++ b/docs/thunder.md
@@ -37,4 +37,4 @@ Thunder is a mysql replication slave. The replication user is called replication
 
 *  It doesn't like talking to USB keyboards.
 
-*  `<del>`One of the older disks (disk 2), may be dodgy.`</del>` They were both dodgy. They died. I cried.
+*  ~~One of the older disks (disk 2), may be dodgy.~~ They were both dodgy. They died. I cried.

--- a/docs/worf_plan.md
+++ b/docs/worf_plan.md
@@ -4,7 +4,7 @@ Page for discussing the pending move of /storage from minerva to worf on 6th/7th
 
 ### Before Down Time
 
-*  `<del>`Announce Down time -- Lotta sending initial notice today or tomorrow, more information next week`</del>`
+*  ~~Announce Down time -- Lotta sending initial notice today or tomorrow, more information next week~~
 
 *  Rsync /storage to worf mounted on Ceiling Cat
 


### PR DESCRIPTION
```
find ./docs -type f -exec sed -i 's/`<del>`/~~/g' {} +
find ./docs -type f -exec sed -i 's/`<\/del>`/~~/g' {} +
```
