### PR TITLE
mkdocs: use Redbrick fonts

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,7 @@
+@import url("https://raw.githubusercontent.com/redbrick/design-system/main/assets/fonts/myriad-pro/loader.css");
+@import url("https://raw.githubusercontent.com/redbrick/design-system/main/assets/fonts/fira-code/loader.css");
+
+:root {
+  --md-text-font: "Myriad Pro", sans-serif;
+  --md-code-font: "Fira Code", monospace;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,3 +47,6 @@ markdown_extensions:
 
 extra:
   github_org: https://github.com/redbrick
+
+extra_css:
+  - stylesheets/extra.css


### PR DESCRIPTION
updates `mkdocs.yml` and adds css to use fonts defined in the Redbrick [design-system](https://github.com/redbrick/design-system) repo

The standard font works as of now but we should wait for [this](https://github.com/redbrick/design-system/pull/1) PR to be merged for the monospace font.