### PR TITLE
Migrating to properdocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install -r requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: pip install -r requirements.txt properdocs
+      - run: properdocs gh-deploy --force

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -55,6 +55,7 @@ plugins:
       tags_file: tags.md
   - git-revision-date-localized:
       type: timeago
+      fallback_to_build_date: true
   - redirects:
       redirect_maps:
         'aperture/index.md': 'hardware/aperture/index.md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+properdocs
 mkdocs-material
 mkdocs-git-revision-date-localized-plugin
 mkdocs-awesome-pages-plugin


### PR DESCRIPTION
This pull request migrates from mkdocs. 

When installing and using Mkdocs, you get the following:
```
The owner of MkDocs has completely abandoned maintenance of the project, and instead is 
planning to publish a "version 2" which will not support any existing themes, plugins or even 
your configuration files. This v2 may eventually replace what you download with pip install 
mkdocs, suddenly breaking the build of your existing site.

To avoid these risks, switch to ProperDocs, a continuation of MkDocs 1.x and a drop-in 
replacement that supports your current MkDocs setup.
```