### PR TITLE
Documentation for atlas

### DIFF
--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -116,6 +116,7 @@ A multi-stage Docker build is used:
 - Deployments use Nomad job specifications in `.github/deploy/` for:
     - **Production** (`production.hcl`)
     - **Review** per-branch (`review.hcl`)
+
 ## Running locally with Docker
 
 To run the site locally in a Docker container (serving the production build via Nginx):

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -106,8 +106,8 @@ yarn build
 
 A multi-stage Docker build is used:
 
-1. **build stage**: installs deps + runs `yarn build` to generate `dist/`
-2. **production stage**: serves `dist/` via `nginx`
+1. **Build stage**: installs deps + runs `yarn build` to generate `dist/`
+2. **Production stage**: serves `dist/` via `nginx`
 
 ## Deployments (high-level)
 

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -120,6 +120,7 @@ A multi-stage Docker build is used:
 ## Running locally with Docker
 
 To run the site locally in a Docker container (serving the production build via Nginx):
+
 1. Build the Docker image:
 
 ```bash
@@ -136,6 +137,7 @@ docker run -p 8080:80 redbrick-atlas
 > When making changes note that the docker image will need to be rebuilt to see the changes reflected in the container.
 
 ## Creating a new page
+
 1. Create a new Markdown file in `src/site/` (e.g., `src/site/new-page.md`).
 2. Add front matter and content:
 

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -10,7 +10,7 @@ title: Atlas
 
 # Atlas (Redbrick Website)
 
-Atlas is Redbrick’s static website, built with [Eleventy (11ty)](https://www.11ty.dev/) and styled with Tailwind CSS + PostCSS. The site output is generated into `dist/` and can be served locally during development, or built into a production container served by Nginx.
+Atlas is Redbrick's static website, built with [Eleventy (11ty)](https://www.11ty.dev/) and styled with Tailwind CSS + PostCSS. The site output is generated into `dist/` and can be served locally during development, or built into a production container served by Nginx.
 
 ## Quick links
 

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -14,7 +14,7 @@ Atlas is Redbrick's static website, built with [Eleventy (11ty)](https://www.11t
 
 ## Quick links
 
-- Live site: [https://redbrick.dcu.ie](https://redbrick.dcu.ie)
+- Live site: <https://redbrick.dcu.ie>
 
 ## Tech stack / tooling
 

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -83,7 +83,7 @@ yarn build
 │   ├── _includes/                  # Includes/partials used by templates
 │   ├── _layouts/                   # Layout templates
 │   └── site/                       # Main Eleventy input directory
-│       ├── assets/                # Static assets (images, fonts, etc.)
+│       ├── assets/                 # Static assets (images, fonts, etc.)
 │       ├── index.md                # Homepage content
 │       ├── links.md                # Links page content
 │       └── 404.md                  # 404 page content

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -116,8 +116,6 @@ A multi-stage Docker build is used:
 - Deployments use Nomad job specifications in `.github/deploy/` for:
     - **Production** (`production.hcl`)
     - **Review** per-branch (`review.hcl`)
-
-
 ## Running locally with Docker
 
 To run the site locally in a Docker container (serving the production build via Nginx):
@@ -160,6 +158,7 @@ layout: default.njk
 Navigation links are defined in `src/_data/site.yml` under navigation and global taking a `- text` which is the text shown in the nav and a `link` which is the path to the page (e.g., `/new-page` for `src/site/new-page.md`).
 
 ## Outside contributions
+
 - Contributions to the website are always welcome!
 
 > [!WARNING]

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -1,0 +1,157 @@
+---
+id: atlas
+aliases:
+  - Atlas
+tags:
+  - webgroup
+  - website
+title: Atlas
+---
+
+# Atlas (Redbrick Website)
+
+Atlas is Redbrick’s static website, built with [Eleventy (11ty)](https://www.11ty.dev/) and styled with Tailwind CSS + PostCSS. The site output is generated into `dist/` and can be served locally during development, or built into a production container served by Nginx.
+
+## Quick links
+
+- Live site: [https://redbrick.dcu.ie](https://redbrick.dcu.ie)
+
+## Tech stack / tooling
+
+- **Node.js**: `^18.17 || ^20`
+- **Package manager**: Yarn (`yarn@4.1.0`, via Corepack)
+- **Static site generator**: Eleventy (`@11ty/eleventy`)
+- **Templating**: Nunjucks (`.njk`) + Markdown (`.md`) + HTML
+- **CSS**: Tailwind CSS + PostCSS (Autoprefixer)
+- **Search**: Pagefind
+- **Container build/runtime**: multi-stage Docker build (Node build → Nginx runtime)
+- **CI/CD**: GitHub Actions (build/publish + deploy)
+
+## Development
+
+Install dependencies:
+
+```bash
+corepack enable
+yarn
+```
+
+Run a dev server:
+
+```bash
+yarn dev
+```
+
+Build for production (outputs to `dist/`):
+
+```bash
+yarn build
+```
+
+## Build output
+
+- Eleventy input: `src/site`
+- Eleventy output: `dist`
+
+(These are configured in `package.json` under the `eleventy.dir` section.)
+
+## File structure breakdown
+
+> Note: `dist/` is generated at build time and is not committed.
+
+```text
+.
+├── .github/
+│   ├── deploy/
+│   │   ├── production.hcl          # Nomad job spec for production deployment
+│   │   └── review.hcl              # Nomad job spec for review (branch) deployments
+│   └── workflows/
+│       ├── build.yml               # Build & publish Docker image to GHCR
+│       └── deploy.yml              # Deploy workflow (prod + review environments)
+├── eleventy/
+│   ├── filters/
+│   │   └── slugify.js              # Custom filter(s) for templates
+│   ├── parsers/
+│   │   └── markdown.js             # Markdown parser configuration
+│   ├── plugins/
+│   │   ├── git-build.js            # Build metadata from git
+│   │   ├── navigation-render.js    # Navigation rendering helper
+│   │   └── pagefind.js             # Pagefind integration
+│   └── utils/                      # Eleventy utility code (helpers)
+├── src/
+│   ├── _data/                      # Eleventy data files (global/site data)
+│   ├── _includes/                  # Includes/partials used by templates
+│   ├── _layouts/                   # Layout templates
+│   └── site/                       # Main Eleventy input directory
+│       ├── assets/                # Static assets (images, fonts, etc.)
+│       ├── index.md                # Homepage content
+│       ├── links.md                # Links page content
+│       └── 404.md                  # 404 page content
+├── .dockerignore
+├── .editorconfig
+├── .eleventy.js                    # Eleventy config entrypoint
+├─  .eleventyignore
+├── .gitattributes
+├── .gitignore
+├── Dockerfile                      # Multi-stage build (Node -> Nginx)
+├── nginx.conf                      # Nginx config for serving the built site
+├── postcss.config.js               # PostCSS configuration
+├── tailwind.config.js              # Tailwind configuration
+├── package.json                    # Scripts + dependencies + Eleventy directory config
+├── yarn.lock
+└── LICENSE
+```
+
+## Docker
+
+A multi-stage Docker build is used:
+
+1. **build stage**: installs deps + runs `yarn build` to generate `dist/`
+2. **production stage**: serves `dist/` via `nginx`
+
+## Deployments (high-level)
+
+- Docker images are built and published via GitHub Actions.
+- Deployments use Nomad job specifications in `.github/deploy/` for:
+  - **production** (`production.hcl`)
+  - **review environments** per-branch (`review.hcl`)
+
+
+## Running locally with Docker
+
+To run the site locally in a Docker container (serving the production build via Nginx):
+1. Build the Docker image:
+
+```bash
+docker build -t redbrick-atlas .
+```
+2. Run the container:
+
+```bash
+docker run -p 8080:80 redbrick-atlas
+```
+3. Access the site at `http://localhost:8080`.
+
+> [!NOTE]
+> When making changes note that the docker image will need to be rebuilt to see the changes reflected in the container.
+
+## Creating a new page
+1. Create a new Markdown file in `src/site/` (e.g., `src/site/new-page.md`).
+2. Add front matter and content:
+
+```markdown
+---
+layout: default.njk
+---
+<main>
+    {% include "newpage.njk" %}
+</main> 
+```
+
+> [!NOTE]
+> We advise using a nunjucks include for the page content to keep the Markdown file clean and focused on content, while the layout and styling can be handled in the included Nunjucks template.
+
+3. Create the corresponding Nunjucks template in `src/_includes/` (e.g., `src/_includes/newpage.njk`) and add your HTML content there.
+4. Link to the new page from the navigation or other pages as needed.
+
+Navigation links are defined in `src/_data/site.yml` under navigation and global taking a `- text` which is the text shown in the nav and a `link` which is the path to the page (e.g., `/new-page` for `src/site/new-page.md`).

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -134,7 +134,7 @@ docker run -p 8080:80 redbrick-atlas
 3. Access the site at [`http://localhost:8080`](http://localhost:8080).
 
 > [!NOTE]
-> When making changes note that the docker image will need to be rebuilt to see the changes reflected in the container.
+> When making changes the docker image will need to be re-built and re-run to see the changes reflected in the container.
 
 ## Creating a new page
 

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -113,8 +113,8 @@ A multi-stage Docker build is used:
 
 - Docker images are built and published via GitHub Actions.
 - Deployments use Nomad job specifications in `.github/deploy/` for:
-  - **production** (`production.hcl`)
-  - **review environments** per-branch (`review.hcl`)
+    - **Production** (`production.hcl`)
+    - **Review** per-branch (`review.hcl`)
 
 
 ## Running locally with Docker
@@ -155,3 +155,9 @@ layout: default.njk
 4. Link to the new page from the navigation or other pages as needed.
 
 Navigation links are defined in `src/_data/site.yml` under navigation and global taking a `- text` which is the text shown in the nav and a `link` which is the path to the page (e.g., `/new-page` for `src/site/new-page.md`).
+
+## Outside contributions
+- Contributions to the website are always welcome!
+
+> [!WARNING]
+> If you want to have the preview deployment for a Pull request the PR must be opened from a branch in the main repository (not a fork) due to GitHub Actions permissions. If you want to open a PR from a fork, you will need to merge it into a branch in the repoisitory and open the PR from there to have the preview deployment. If you are not able to do this, ask a webgroup member to open the PR for you or to merge your PR into a branch in the repository.

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -125,11 +125,13 @@ To run the site locally in a Docker container (serving the production build via 
 ```bash
 docker build -t redbrick-atlas .
 ```
+
 2. Run the container:
 
 ```bash
 docker run -p 8080:80 redbrick-atlas
 ```
+
 3. Access the site at [`http://localhost:8080`](http://localhost:8080).
 
 > [!NOTE]

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -131,7 +131,7 @@ docker build -t redbrick-atlas .
 ```bash
 docker run -p 8080:80 redbrick-atlas
 ```
-3. Access the site at `http://localhost:8080`.
+3. Access the site at [`http://localhost:8080`](http://localhost:8080).
 
 > [!NOTE]
 > When making changes note that the docker image will need to be rebuilt to see the changes reflected in the container.

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -18,14 +18,14 @@ Atlas is Redbrick's static website, built with [Eleventy (11ty)](https://www.11t
 
 ## Tech stack / tooling
 
-- **Node.js**: `^18.17 || ^20`
-- **Package manager**: Yarn (`yarn@4.1.0`, via Corepack)
-- **Static site generator**: Eleventy (`@11ty/eleventy`)
-- **Templating**: Nunjucks (`.njk`) + Markdown (`.md`) + HTML
-- **CSS**: Tailwind CSS + PostCSS (Autoprefixer)
-- **Search**: Pagefind
+- [**Node.js**](https://nodejs.org/en): `^18.17 || ^20`
+- **Package manager**: [Yarn](https://yarnpkg.com/) (`yarn@4.1.0`, via Corepack)
+- **Static site generator**: [Eleventy](https://www.11ty.dev/) (`@11ty/eleventy`)
+- **Templating**: [Nunjucks](https://mozilla.github.io/nunjucks/) (`.njk`) + Markdown (`.md`) + HTML
+- **CSS**: [Tailwind CSS](https://tailwindcss.com/) + [PostCSS](https://postcss.org/) (Autoprefixer)
+- **Search**: [Pagefind](https://pagefind.app/)
 - **Container build/runtime**: multi-stage Docker build (Node build → Nginx runtime)
-- **CI/CD**: GitHub Actions (build/publish + deploy)
+- **CI/CD**: [GitHub Actions](https://github.com/features/actions) (build/publish + deploy)
 
 ## Development
 

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -151,7 +151,7 @@ layout: default.njk
 ```
 
 > [!NOTE]
-> We advise using a nunjucks include for the page content to keep the Markdown file clean and focused on content, while the layout and styling can be handled in the included Nunjucks template.
+> We advise using a [nunjucks include](https://mozilla.github.io/nunjucks/templating.html#include) for the page content to keep the Markdown file clean and focused on content, while the layout and styling can be handled in the included Nunjucks template.
 
 3. Create the corresponding Nunjucks template in `src/_includes/` (e.g., `src/_includes/newpage.njk`) and add your HTML content there.
 4. Link to the new page from the navigation or other pages as needed.

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -57,7 +57,8 @@ yarn build
 
 ## File structure breakdown
 
-> Note: `dist/` is generated at build time and is not committed.
+> [!NOTE]
+> `dist/` is generated at build time and is not committed.
 
 ```text
 .

--- a/docs/webgroup/atlas.md
+++ b/docs/webgroup/atlas.md
@@ -51,7 +51,7 @@ yarn build
 ## Build output
 
 - Eleventy input: `src/site`
-- Eleventy output: `dist`
+- Eleventy output: `dist/`
 
 (These are configured in `package.json` under the `eleventy.dir` section.)
 

--- a/docs/webgroup/index.md
+++ b/docs/webgroup/index.md
@@ -21,4 +21,4 @@ A Discord bot, written in Python, that is maintained by the Redbrick Webgroup.
 
 ### [Atlas (Redbrick Website)](atlas.md)
 
-A static website, written in Eleventy (11ty), that is maintained by the Redbrick Webgroup. The website is hosted at [https://redbrick.dcu.ie](https://redbrick.dcu.ie).
+A static website, written in Eleventy (11ty), that is maintained by the Redbrick Webgroup. The website is hosted at <https://redbrick.dcu.ie>.

--- a/docs/webgroup/index.md
+++ b/docs/webgroup/index.md
@@ -18,3 +18,7 @@ Read more about how the webgroup operates in [open governance](https://redbrick.
 ### [Blockbot](blockbot.md)
 
 A Discord bot, written in Python, that is maintained by the Redbrick Webgroup.
+
+### [Atlas (Redbrick Website)](atlas.md)
+
+A static website, written in Eleventy (11ty), that is maintained by the Redbrick Webgroup. The website is hosted at [https://redbrick.dcu.ie](https://redbrick.dcu.ie).


### PR DESCRIPTION
This Pull Request adds documentation on the [Atlas](https://github.com/redbrick/atlas) website with information regarding 11ty, project structure and how to add new pages.